### PR TITLE
Expose APIs for entity and item names

### DIFF
--- a/Daybreak.GWCA/header/EntityNameModule.h
+++ b/Daybreak.GWCA/header/EntityNameModule.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "httplib.h"
 
-namespace Daybreak::Modules::NameModule {
+namespace Daybreak::Modules::EntityNameModule {
     void GetName(const httplib::Request& req, httplib::Response& res);
 }

--- a/Daybreak.GWCA/header/GameStateModule.h
+++ b/Daybreak.GWCA/header/GameStateModule.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "httplib.h"
+
+namespace Daybreak::Modules::GameStateModule {
+    void GetGameStateInfo(const httplib::Request&, httplib::Response& res);
+}

--- a/Daybreak.GWCA/header/ItemNameModule.h
+++ b/Daybreak.GWCA/header/ItemNameModule.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "httplib.h"
+
+namespace Daybreak::Modules::ItemNameModule {
+    void GetName(const httplib::Request& req, httplib::Response& res);
+}

--- a/Daybreak.GWCA/header/Utils.h
+++ b/Daybreak.GWCA/header/Utils.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace Daybreak::Utils {
+    std::string WStringToString(const std::wstring& wstr);
+    bool StringToInt(const std::string& str, int& outValue);
+}

--- a/Daybreak.GWCA/header/payloads/GameStatePayload.h
+++ b/Daybreak.GWCA/header/payloads/GameStatePayload.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <cstdint>
+#include <json.hpp>
+#include <payloads/StatePayload.h>
+
+using json = nlohmann::json;
+
+namespace Daybreak {
+    struct GameStatePayload {
+        std::list<StatePayload> States;
+    };
+
+    void to_json(json& j, const GameStatePayload& p);
+}

--- a/Daybreak.GWCA/header/payloads/StatePayload.h
+++ b/Daybreak.GWCA/header/payloads/StatePayload.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstdint>
+#include <json.hpp>
+
+using json = nlohmann::json;
+
+namespace Daybreak {
+    struct StatePayload {
+        uint32_t Id = 0;
+        float PosX = 0;
+        float PosY = 0;
+        uint32_t State = 0;
+    };
+
+    void to_json(json& j, const StatePayload& p);
+}

--- a/Daybreak.GWCA/source/EntityNameModule.cpp
+++ b/Daybreak.GWCA/source/EntityNameModule.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
-#include "NameModule.h"
+#include "EntityNameModule.h"
 #include "payloads/NamePayload.h"
 #include <GWCA/Managers/GameThreadMgr.h>
 #include <GWCA/Managers/MapMgr.h>
@@ -14,24 +14,14 @@
 #include <Windows.h>
 #include <cstdint>
 #include <limits>
+#include "Utils.h"
 
-namespace Daybreak::Modules::NameModule {
+namespace Daybreak::Modules::EntityNameModule {
     std::vector<std::tuple<uint32_t, std::promise<NamePayload>*, std::wstring*>> WaitingList;
     std::queue<std::tuple<uint32_t, std::promise<NamePayload>>*> PromiseQueue;
     std::mutex GameThreadMutex;
     GW::HookEntry GameThreadHook;
     volatile bool initialized = false;
-
-    std::string WStringToString(const std::wstring& wstr)
-    {
-        if (wstr.empty()) return std::string();
-
-        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
-        std::string strTo(size_needed, 0);
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
-
-        return strTo;
-    }
 
     std::wstring* GetAsyncName(uint32_t id) {
         NamePayload namePayload;
@@ -90,7 +80,7 @@ namespace Daybreak::Modules::NameModule {
                     WaitingList.erase(WaitingList.begin() + i);
                     NamePayload payload;
                     payload.Id = id;
-                    payload.Name = WStringToString(*name);
+                    payload.Name = Daybreak::Utils::WStringToString(*name);
                     delete(name);
                     promise->set_value(payload);
                 }

--- a/Daybreak.GWCA/source/GameModule.cpp
+++ b/Daybreak.GWCA/source/GameModule.cpp
@@ -24,23 +24,13 @@
 #include <json.hpp>
 #include <queue>
 #include <algorithm>
+#include "Utils.h"
 
 namespace Daybreak::Modules::GameModule {
     std::queue<std::promise<GamePayload>*> PromiseQueue;
     std::mutex GameThreadMutex;
     GW::HookEntry GameThreadHook;
     volatile bool initialized = false;
-
-    std::string GetString(wchar_t* chars) {
-        if (!chars) {
-            return "";
-        }
-
-        std::string str(64, '\0');
-        auto length = std::wcstombs(&str[0], chars, 64);
-        str.resize(length);
-        return str;
-    }
 
     std::list<QuestMetadata> GetQuestLog() {
         std::list<QuestMetadata> questMetadatas;
@@ -291,7 +281,8 @@ namespace Daybreak::Modules::GameModule {
         GW::Title gwTitle;
         Title title;
         int titleId = 0;
-        auto name = GetString(gwPlayer->name);
+        std::wstring nameString(gwPlayer->name);
+        auto name = Daybreak::Utils::WStringToString(nameString);
         player.Name = name;
 
         for (const auto &t : titles) {

--- a/Daybreak.GWCA/source/GameStateModule.cpp
+++ b/Daybreak.GWCA/source/GameStateModule.cpp
@@ -1,0 +1,104 @@
+#include "pch.h"
+#include "GameStateModule.h"
+#include <GWCA/Managers/GameThreadMgr.h>
+#include <GWCA/Managers/AgentMgr.h>
+#include <GWCA/GameEntities/Agent.h>
+#include <GWCA/Managers/MapMgr.h>
+#include <future>
+#include <payloads/GameStatePayload.h>
+#include <json.hpp>
+#include <queue>
+#include <algorithm>
+
+namespace Daybreak::Modules::GameStateModule {
+    std::queue<std::promise<GameStatePayload>*> PromiseQueue;
+    std::mutex GameThreadMutex;
+    GW::HookEntry GameThreadHook;
+    volatile bool initialized = false;
+
+    std::list<GW::AgentLiving> GetLivingAgents() {
+        std::list<GW::AgentLiving> agentList;
+        const GW::AgentArray* agents_ptr = GW::Agents::GetAgentArray();
+        GW::AgentArray* agents = GW::Agents::GetAgentArray();
+        if (!agents) {
+            return agentList;
+        }
+
+        for (auto* a : *agents) {
+            const GW::AgentLiving* agent = a ? a->GetAsAgentLiving() : nullptr;
+            if (agent) {
+                agentList.push_back(*agent);
+            }
+        }
+
+        return agentList;
+    }
+
+    std::list<StatePayload> GetStates(
+        std::list<GW::AgentLiving> agents) {
+        std::list<StatePayload> states;
+        for (auto& agent : agents) {
+            StatePayload state;
+            state.Id = agent.agent_id;
+            state.PosX = agent.pos.x;
+            state.PosY = agent.pos.y;
+            state.State = agent.type_map;
+            states.push_back(state);
+        }
+
+        return states;
+    }
+
+    GameStatePayload GetPayload() {
+        GameStatePayload gamePayload;
+        if (!GW::Map::GetIsMapLoaded()) {
+            return gamePayload;
+        }
+
+        auto agents = GetLivingAgents();
+        if (agents.empty()) {
+            return gamePayload;
+        }
+
+        auto states = GetStates(agents);
+        gamePayload.States = states;
+        return gamePayload;
+    }
+
+    void EnsureInitialized() {
+        GameThreadMutex.lock();
+        if (!initialized) {
+            GW::GameThread::RegisterGameThreadCallback(&GameThreadHook, [&](GW::HookStatus*) {
+                while (!PromiseQueue.empty()) {
+                    auto promise = PromiseQueue.front();
+                    PromiseQueue.pop();
+                    try {
+                        auto payload = GetPayload();
+                        promise->set_value(payload);
+                    }
+                    catch (...) {
+                        GameStatePayload payload;
+                        promise->set_value(payload);
+                    }
+                }
+                });
+
+            initialized = true;
+        }
+
+        GameThreadMutex.unlock();
+    }
+
+    void GetGameStateInfo(const httplib::Request&, httplib::Response& res) {
+        auto callbackEntry = new GW::HookEntry;
+        auto response = new std::promise<GameStatePayload>;
+
+        EnsureInitialized();
+        PromiseQueue.emplace(response);
+        json responsePayload = response->get_future().get();
+
+        delete callbackEntry;
+        delete response;
+        res.set_content(responsePayload.dump(), "text/json");
+    }
+}

--- a/Daybreak.GWCA/source/ItemNameModule.cpp
+++ b/Daybreak.GWCA/source/ItemNameModule.cpp
@@ -1,0 +1,193 @@
+#include "pch.h"
+#include "ItemNameModule.h"
+#include "payloads/NamePayload.h"
+#include <GWCA/Managers/GameThreadMgr.h>
+#include <GWCA/Managers/ItemMgr.h>
+#include <GWCA/GameEntities/Item.h>
+#include <future>
+#include <json.hpp>
+#include <tuple>
+#include <queue>
+#include <GWCA/GWCA.h>
+#include <Windows.h>
+#include <cstdint>
+#include <limits>
+#include <Utils.h>
+
+namespace Daybreak::Modules::ItemNameModule {
+    std::vector<std::tuple<uint32_t, std::promise<NamePayload>*, std::wstring*>> WaitingList;
+    std::queue<std::tuple<uint32_t, std::list<uint32_t>, std::promise<NamePayload>>*> PromiseQueue;
+    std::mutex GameThreadMutex;
+    GW::HookEntry GameThreadHook;
+    volatile bool initialized = false;
+
+
+    // TODO #442: Delete this once it is merged into GWCA
+    GW::Item* GetItemByModelIdAndModifiers(uint32_t modelid, const std::list<GW::ItemModifier> modifiers, int bagStart, int bagEnd) {
+        GW::Bag** bags = GW::Items::GetBagArray();
+        GW::Bag* bag = NULL;
+
+        for (int bagIndex = bagStart; bagIndex <= bagEnd; ++bagIndex) {
+            bag = bags[bagIndex];
+            if (!(bag && bag->items.valid())) continue;
+            for (GW::Item* item : bag->items) {
+                if (item && item->model_id == modelid && item->mod_struct_size == modifiers.size()) {
+                    auto match = true;
+                    auto listIt = modifiers.begin();
+                    for (uint32_t i = 0; i < item->mod_struct_size; i++) {
+                        // Compare each element from the array to the corresponding element in the list
+                        if (!(item->mod_struct[i] == *listIt)) {
+                            match = false;
+                            break;
+                        }
+                        ++listIt;
+                    }
+
+                    if (match) {
+                        return item;
+                    }
+                }
+            }
+        }
+
+        return NULL;
+    }
+
+    std::wstring* GetAsyncName(uint32_t id, std::list<uint32_t> modifiers) {
+        std::list<GW::ItemModifier> parsedModifiers;
+        for (auto mod : modifiers) {
+            GW::ItemModifier parsedModifier;
+            parsedModifier.mod = mod;
+            parsedModifiers.push_back(parsedModifier);
+        }
+
+        auto item = GetItemByModelIdAndModifiers(id, parsedModifiers, 1, 23);
+        if (!item) {
+            return nullptr;
+        }
+
+        auto name = new std::wstring();
+        GW::Items::AsyncGetItemByName(item, *name);
+        return name;
+    }
+
+    void EnsureInitialized() {
+        GameThreadMutex.lock();
+        if (!initialized) {
+            GW::GameThread::RegisterGameThreadCallback(&GameThreadHook, [&](GW::HookStatus*) {
+                while (!PromiseQueue.empty()) {
+                    auto promiseRequest = PromiseQueue.front();
+                    std::promise<NamePayload> &promise = std::get<2>(*promiseRequest);
+                    uint32_t id = std::get<0>(*promiseRequest);
+                    auto modifiers = std::get<1>(*promiseRequest);
+                    PromiseQueue.pop();
+                    try {
+                        auto name = GetAsyncName(id, modifiers);
+                        if (!name) {
+                            continue;
+                        }
+
+                        WaitingList.emplace_back(id, &promise, name);
+                    }
+                    catch (...) {
+                        NamePayload payload;
+                        promise.set_value(payload);
+                    }
+                }
+
+                for (size_t i = 0; i < WaitingList.size(); ) {
+                    auto item = &WaitingList[i];
+                    auto name = std::get<2>(*item);
+                    if (name->empty()) {
+                        i++;
+                        continue;
+                    }
+
+                    auto promise = std::get<1>(*item);
+                    auto id = std::get<0>(*item);
+                    WaitingList.erase(WaitingList.begin() + i);
+                    NamePayload payload;
+                    payload.Id = id;
+                    payload.Name = Daybreak::Utils::WStringToString(*name);
+                    delete(name);
+                    promise->set_value(payload);
+                }
+                });
+
+            initialized = true;
+        }
+
+        GameThreadMutex.unlock();
+    }
+
+    std::vector<std::string> SplitAndRemoveSpaces(const std::string& s) {
+        std::vector<std::string> result;
+        std::stringstream ss(s);
+        std::string item;
+
+        while (getline(ss, item, ',')) {
+            item.erase(std::remove(item.begin(), item.end(), ' '), item.end());
+            result.push_back(item);
+        }
+
+        return result;
+    }
+
+    void GetName(const httplib::Request& req, httplib::Response& res) {
+        auto callbackEntry = new GW::HookEntry;
+        uint32_t id = 0;
+        std::list<uint32_t> modifiers;
+        
+        auto id_it = req.params.find("id");
+        if (id_it == req.params.end()) {
+            res.status = 400;
+            res.set_content("Missing id parameter", "text/plain");
+            return;
+        }
+        else {
+            auto& idStr = id_it->second;
+            int parsedId;
+            if (!Daybreak::Utils::StringToInt(idStr, parsedId)){
+                res.status = 400;
+                res.set_content("Invalid id parameter", "text/plain");
+                return;
+            }
+
+            id = static_cast<uint32_t>(parsedId);
+        }
+
+        auto mod_it = req.params.find("modifiers");
+        if (mod_it == req.params.end()) {
+            res.status = 400;
+            res.set_content("Missing modifiers parameter", "text/plain");
+            return;
+        }
+        else {
+            auto& modifiersStr = mod_it->second;
+            const auto tokens = SplitAndRemoveSpaces(modifiersStr);
+            for (const auto& token : tokens) {
+                int parsedModifier;
+                if (!Daybreak::Utils::StringToInt(token, parsedModifier)) {
+                    res.status = 400;
+                    res.set_content("Invalid modifier parameter", "text/plain");
+                    return;
+                }
+
+                modifiers.push_back(static_cast<uint32_t>(parsedModifier));
+            }
+        }
+
+        auto response = new std::tuple<uint32_t, std::list<uint32_t>, std::promise<NamePayload>>();
+        std::get<0>(*response) = id;
+        std::promise<NamePayload>& promise = std::get<2>(*response);
+        std::get<1>(*response) = modifiers;
+
+        EnsureInitialized();
+        PromiseQueue.emplace(response);
+
+        json responsePayload = promise.get_future().get();
+        delete callbackEntry;
+        delete response;
+        res.set_content(responsePayload.dump(), "text/json");
+    }
+}

--- a/Daybreak.GWCA/source/LoginModule.cpp
+++ b/Daybreak.GWCA/source/LoginModule.cpp
@@ -7,6 +7,7 @@
 #include <payloads/LoginPayload.h>
 #include <json.hpp>
 #include <queue>
+#include "Utils.h"
 
 namespace Daybreak::Modules::LoginModule {
     std::queue<std::promise<LoginPayload>*> PromiseQueue;
@@ -17,15 +18,10 @@ namespace Daybreak::Modules::LoginModule {
     LoginPayload GetPayload() {
         auto context = GW::GetCharContext();
         LoginPayload loginPayload;
-        std::string emailstr(64, '\0');
-        auto length = std::wcstombs(&emailstr[0], context->player_email, 64);
-        emailstr.resize(length);
-        loginPayload.Email = emailstr;
-    
-        std::string playerstr(20, '\0');
-        length = std::wcstombs(&playerstr[0], context->player_name, 20);
-        playerstr.resize(length);
-        loginPayload.PlayerName = playerstr;
+        std::wstring playerEmail(context->player_email);
+        std::wstring playerName(context->player_name);
+        loginPayload.Email = Daybreak::Utils::WStringToString(playerEmail);
+        loginPayload.PlayerName = Daybreak::Utils::WStringToString(playerName);
 
         return loginPayload;
     }

--- a/Daybreak.GWCA/source/MainPlayerModule.cpp
+++ b/Daybreak.GWCA/source/MainPlayerModule.cpp
@@ -24,23 +24,13 @@
 #include <json.hpp>
 #include <queue>
 #include <algorithm>
+#include "Utils.h"
 
 namespace Daybreak::Modules::MainPlayerModule {
     std::queue<std::promise<MainPlayer>*> PromiseQueue;
     std::mutex GameThreadMutex;
     GW::HookEntry GameThreadHook;
     volatile bool initialized = false;
-
-    std::string GetString(wchar_t* chars) {
-        if (!chars) {
-            return "";
-        }
-
-        std::string str(64, '\0');
-        auto length = std::wcstombs(&str[0], chars, 64);
-        str.resize(length);
-        return str;
-    }
 
     std::list<QuestMetadata> GetQuestLog() {
         std::list<QuestMetadata> questMetadatas;
@@ -291,7 +281,8 @@ namespace Daybreak::Modules::MainPlayerModule {
         GW::Title gwTitle;
         Title title;
         int titleId = 0;
-        auto name = GetString(gwPlayer->name);
+        std::wstring gwPlayerName(gwPlayer->name);
+        auto name = Daybreak::Utils::WStringToString(gwPlayerName);
         player.Name = name;
 
         for (const auto &t : titles) {

--- a/Daybreak.GWCA/source/Utils.cpp
+++ b/Daybreak.GWCA/source/Utils.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+#include <iostream>
+#include <limits>
+#include <windows.h>
+#include <string>
+#include <cstdint>
+
+namespace Daybreak::Utils {
+    std::string WStringToString(const std::wstring& wstr)
+    {
+        if (wstr.empty()) return std::string();
+
+        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+        std::string strTo(size_needed, 0);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+
+        return strTo;
+    }
+
+    bool StringToInt(const std::string& str, int& outValue) {
+        size_t pos = 0;
+        unsigned long result = std::stoul(str, &pos);
+
+        // Ensure the entire string was processed
+        if (pos != str.size()) {
+            return false;
+        }
+
+        outValue = static_cast<int>(result);
+        return true;
+    }
+}

--- a/Daybreak.GWCA/source/dllmain.cpp
+++ b/Daybreak.GWCA/source/dllmain.cpp
@@ -16,7 +16,9 @@
 #include "GameModule.h"
 #include "MainPlayerModule.h"
 #include "SessionModule.h"
-#include "NameModule.h"
+#include "EntityNameModule.h"
+#include "GameStateModule.h"
+#include "ItemNameModule.h"
 
 static FILE* stdout_proxy;
 static FILE* stderr_proxy;
@@ -48,8 +50,10 @@ static DWORD WINAPI ThreadProc(LPVOID lpModule)
     http::server::Get("/game", Daybreak::Modules::GameModule::GetGameInfo);
     http::server::Get("/inventory", Daybreak::Modules::InventoryModule::GetInventoryInfo);
     http::server::Get("/game/mainplayer", Daybreak::Modules::MainPlayerModule::GetMainPlayer);
+    http::server::Get("/game/state", Daybreak::Modules::GameStateModule::GetGameStateInfo);
     http::server::Get("/session", Daybreak::Modules::SessionModule::GetSessionInfo);
-    http::server::Get("/name", Daybreak::Modules::NameModule::GetName);
+    http::server::Get("/entities/name", Daybreak::Modules::EntityNameModule::GetName);
+    http::server::Get("/items/name", Daybreak::Modules::ItemNameModule::GetName);
     http::server::StartServer();
 
 #ifdef BUILD_TYPE_DEBUG

--- a/Daybreak.GWCA/source/payloads/GameStatePayload.cpp
+++ b/Daybreak.GWCA/source/payloads/GameStatePayload.cpp
@@ -1,0 +1,14 @@
+#include <cstdint>
+#include <json.hpp>
+#include <payloads/GameStatePayload.h>
+
+using json = nlohmann::json;
+
+namespace Daybreak {
+    void to_json(json& j, const GameStatePayload& p) {
+        j = json
+        {
+            {"States", p.States},
+        };
+    }
+}

--- a/Daybreak.GWCA/source/payloads/StatePayload.cpp
+++ b/Daybreak.GWCA/source/payloads/StatePayload.cpp
@@ -1,0 +1,17 @@
+#include <cstdint>
+#include <json.hpp>
+#include <payloads/StatePayload.h>
+
+using json = nlohmann::json;
+
+namespace Daybreak {
+    void to_json(json& j, const StatePayload& p) {
+        j = json
+        {
+            {"Id", p.Id},
+            {"PosX", p.PosX},
+            {"PosY", p.PosY},
+            {"State", p.State}
+        };
+    }
+}

--- a/Daybreak/Controls/LivingEntityContextMenu.xaml.cs
+++ b/Daybreak/Controls/LivingEntityContextMenu.xaml.cs
@@ -59,7 +59,7 @@ public partial class LivingEntityContextMenu : UserControl
         }
 
         await this.guildwarsMemoryReader.EnsureInitialized(context.GuildWarsApplicationLaunchContext!.GuildWarsProcess, CancellationToken.None);
-        this.EntityName = await this.guildwarsMemoryReader.GetNamedEntity(context.LivingEntity!, CancellationToken.None);
+        this.EntityName = await this.guildwarsMemoryReader.GetEntityName(context.LivingEntity!, CancellationToken.None).ConfigureAwait(true);
     }
 
     private void NpcDefinitionTextBlock_MouseLeftButtonDown(object _, MouseButtonEventArgs e)

--- a/Daybreak/Controls/PlayerContextMenu.xaml.cs
+++ b/Daybreak/Controls/PlayerContextMenu.xaml.cs
@@ -44,7 +44,7 @@ public partial class PlayerContextMenu : UserControl
         }
 
         await this.guildwarsMemoryReader.EnsureInitialized(context.GuildWarsApplicationLaunchContext!.GuildWarsProcess, CancellationToken.None);
-        this.PlayerName = await this.guildwarsMemoryReader.GetNamedEntity(context.Player!, CancellationToken.None);
+        this.PlayerName = await this.guildwarsMemoryReader.GetEntityName(context.Player!, CancellationToken.None).ConfigureAwait(true);
     }
 
     private void TextBlock_MouseLeftButtonDown(object _, MouseButtonEventArgs e)

--- a/Daybreak/Controls/Templates/BagItemMenu.xaml
+++ b/Daybreak/Controls/Templates/BagItemMenu.xaml
@@ -20,7 +20,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
-        <TextBlock Text="{Binding Item.Name}"
+        <TextBlock Text="{Binding ElementName=_this, Path=ItemName, Mode=OneWay}"
                    FontSize="16"
                    Grid.Row="0"
                    Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"

--- a/Daybreak/Controls/Templates/BagItemMenu.xaml.cs
+++ b/Daybreak/Controls/Templates/BagItemMenu.xaml.cs
@@ -1,8 +1,11 @@
 ﻿using Daybreak.Models.Guildwars;
+using Daybreak.Services.Scanner;
 using Daybreak.Services.TradeChat;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Core.Extensions;
+using System.Linq;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Extensions;
@@ -14,22 +17,28 @@ namespace Daybreak.Controls.Templates;
 /// </summary>
 public partial class BagItemMenu : UserControl
 {
+    private readonly IGuildwarsMemoryReader guildwarsMemoryReader;
     private readonly IItemHashService itemHashService;
 
     public event EventHandler? CloseClicked;
     public event EventHandler<ItemBase>? ItemWikiClicked;
 
     [GenerateDependencyProperty]
+    private string itemName = string.Empty;
+    [GenerateDependencyProperty]
     private string modHash = string.Empty;
 
     public BagItemMenu()
-        : this(Launch.Launcher.Instance.ApplicationServiceProvider.GetRequiredService<IItemHashService>())
+        : this(Launch.Launcher.Instance.ApplicationServiceProvider.GetRequiredService<IGuildwarsMemoryReader>(),
+              Launch.Launcher.Instance.ApplicationServiceProvider.GetRequiredService<IItemHashService>())
     {
     }
 
     private BagItemMenu(
+        IGuildwarsMemoryReader guildwarsMemoryReader,
         IItemHashService itemHashService)
     {
+        this.guildwarsMemoryReader = guildwarsMemoryReader.ThrowIfNull();
         this.itemHashService = itemHashService.ThrowIfNull();
         this.InitializeComponent();
     }
@@ -39,7 +48,7 @@ public partial class BagItemMenu : UserControl
         this.CloseClicked?.Invoke(this, e);
     }
 
-    private void UserControl_DataContextChanged(object _, DependencyPropertyChangedEventArgs e)
+    private async void UserControl_DataContextChanged(object _, DependencyPropertyChangedEventArgs e)
     {
         if (this.DataContext is not IBagContent content)
         {
@@ -47,6 +56,16 @@ public partial class BagItemMenu : UserControl
         }
 
         this.ModHash = this.itemHashService.ComputeHash(content);
+        var name = await this.guildwarsMemoryReader.GetItemName(
+            content is BagItem bagItem ? bagItem.Item.Id :
+            content is UnknownBagItem unknownBagItem ? (int)unknownBagItem.ItemId :
+            0,
+            content.Modifiers.Select(mod => mod.Modifier).ToList(),
+            CancellationToken.None).ConfigureAwait(true);
+        if (name is not null)
+        {
+            this.ItemName = name;
+        }
     }
 
     private void WikiTextBlock_MouseLeftButtonDown(object _, MouseButtonEventArgs e)

--- a/Daybreak/Daybreak.csproj
+++ b/Daybreak/Daybreak.csproj
@@ -13,7 +13,7 @@
     <LangVersion>preview</LangVersion>
     <ApplicationIcon>Daybreak.ico</ApplicationIcon>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <Version>0.9.8.132</Version>
+    <Version>0.9.8.133</Version>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UserSecretsId>cfb2a489-db80-448d-a969-80270f314c46</UserSecretsId>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Daybreak/Models/Guildwars/EntityGameState.cs
+++ b/Daybreak/Models/Guildwars/EntityGameState.cs
@@ -1,0 +1,7 @@
+﻿namespace Daybreak.Models.Guildwars;
+public sealed class EntityGameState
+{
+    public int Id { get; set; }
+    public Position Position { get; set; }
+    public LivingEntityState State { get; set; }
+}

--- a/Daybreak/Models/Guildwars/GameState.cs
+++ b/Daybreak/Models/Guildwars/GameState.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Generic;
+
+namespace Daybreak.Models.Guildwars;
+public sealed class GameState
+{
+    public List<EntityGameState>? States { get; init; }
+}

--- a/Daybreak/Models/Guildwars/LivingEntity.cs
+++ b/Daybreak/Models/Guildwars/LivingEntity.cs
@@ -10,7 +10,7 @@ public sealed class LivingEntity : IEntity
 
     public Npc? NpcDefinition { get; init; }
 
-    public Position? Position { get; init; }
+    public Position? Position { get; set; }
 
     public Profession? PrimaryProfession { get; init; }
     
@@ -18,7 +18,7 @@ public sealed class LivingEntity : IEntity
 
     public int Level { get; init; }
 
-    public LivingEntityState State { get; init; }
+    public LivingEntityState State { get; set; }
     
     public LivingEntityAllegiance Allegiance { get; init; }
 }

--- a/Daybreak/Models/Guildwars/MainPlayerInformation.cs
+++ b/Daybreak/Models/Guildwars/MainPlayerInformation.cs
@@ -9,7 +9,7 @@ public sealed class MainPlayerInformation : IEntity
     public TitleInformation? TitleInformation { get; init; }
     public int Id { get; init; }
     public int Level { get; init; }
-    public Position? Position { get; init; }
+    public Position? Position { get; set; }
     public Profession? PrimaryProfession { get; init; }
     public Profession? SecondaryProfession { get; init; }
     public List<Profession>? UnlockedProfession { get; init; }

--- a/Daybreak/Models/Guildwars/PlayerInformation.cs
+++ b/Daybreak/Models/Guildwars/PlayerInformation.cs
@@ -7,7 +7,7 @@ public sealed class PlayerInformation : IEntity
     public int Id { get; init; }
     public uint Timer { get; init; }
     public int Level { get; init; }
-    public Position? Position { get; init; }
+    public Position? Position { get; set; }
     public Profession? PrimaryProfession { get; init; }
     public Profession? SecondaryProfession { get; init; }
     public List<Profession>? UnlockedProfession { get; init; }

--- a/Daybreak/Models/Guildwars/WorldPlayerInformation.cs
+++ b/Daybreak/Models/Guildwars/WorldPlayerInformation.cs
@@ -9,7 +9,7 @@ public sealed class WorldPlayerInformation : IEntity
     public TitleInformation? TitleInformation { get; init; }
     public int Id { get; init; }
     public int Level { get; init; }
-    public Position? Position { get; init; }
+    public Position? Position { get; set; }
     public Profession? PrimaryProfession { get; init; }
     public Profession? SecondaryProfession { get; init; }
     public List<Profession>? UnlockedProfession { get; init; }

--- a/Daybreak/Services/Scanner/GuildwarsMemoryCache.cs
+++ b/Daybreak/Services/Scanner/GuildwarsMemoryCache.cs
@@ -3,6 +3,7 @@ using Daybreak.Models.Guildwars;
 using Daybreak.Models.LaunchConfigurations;
 using Daybreak.Services.Scanner.Models;
 using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Core.Extensions;
 using System.Threading;
@@ -23,8 +24,8 @@ public sealed class GuildwarsMemoryCache : IGuildwarsMemoryCache
     private readonly CachedData<SessionData?> sessionDataCache = new();
     private readonly CachedData<UserData?> userDataCache = new();
     private readonly CachedData<MainPlayerData?> mainPlayerDataCache = new();
-    private readonly CachedData<ConnectionData?> connectionDataCache = new();
     private readonly CachedData<PreGameData?> preGameDataCache = new();
+    private readonly CachedData<GameState?> gameStateCache = new();
 
     public GuildwarsMemoryCache(
         IGuildwarsMemoryReader guildwarsMemoryReader,
@@ -87,6 +88,11 @@ public sealed class GuildwarsMemoryCache : IGuildwarsMemoryCache
     public Task<PreGameData?> ReadPreGameData(CancellationToken cancellationToken)
     {
         return this.ReadDataInternal(this.preGameDataCache, this.guildwarsMemoryReader.ReadPreGameData, cancellationToken);
+    }
+
+    public Task<GameState?> ReadGameState(CancellationToken cancellationToken)
+    {
+        return this.ReadDataInternal(this.gameStateCache, this.guildwarsMemoryReader.ReadGameState, cancellationToken);
     }
 
     private async Task<T?> ReadDataInternal<T>(CachedData<T?> cachedData, Func<CancellationToken, Task<T?>> task, CancellationToken cancellationToken)

--- a/Daybreak/Services/Scanner/IGuildwarsMemoryCache.cs
+++ b/Daybreak/Services/Scanner/IGuildwarsMemoryCache.cs
@@ -18,4 +18,5 @@ public interface IGuildwarsMemoryCache
     Task<UserData?> ReadUserData(CancellationToken cancellationToken);
     Task<MainPlayerData?> ReadMainPlayerData(CancellationToken cancellationToken);
     Task<PreGameData?> ReadPreGameData(CancellationToken cancellationToken);
+    Task<GameState?> ReadGameState(CancellationToken cancellationToken);
 }

--- a/Daybreak/Services/Scanner/IGuildwarsMemoryReader.cs
+++ b/Daybreak/Services/Scanner/IGuildwarsMemoryReader.cs
@@ -1,4 +1,5 @@
 ﻿using Daybreak.Models.Guildwars;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,8 @@ public interface IGuildwarsMemoryReader
     Task<SessionData?> ReadSessionData(CancellationToken cancellationToken);
     Task<MainPlayerData?> ReadMainPlayerData(CancellationToken cancellationToken);
     Task<PreGameData?> ReadPreGameData(CancellationToken cancellationToken);
-    Task<string?> GetNamedEntity(IEntity entity, CancellationToken cancellationToken);
+    Task<GameState?> ReadGameState(CancellationToken cancellationToken);
+    Task<string?> GetEntityName(IEntity entity, CancellationToken cancellationToken);
+    Task<string?> GetItemName(int id, List<uint> modifiers, CancellationToken cancellationToken);
     void Stop();
 }

--- a/Daybreak/Services/Scanner/Models/GameStatePayload.cs
+++ b/Daybreak/Services/Scanner/Models/GameStatePayload.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Generic;
+
+namespace Daybreak.Services.Scanner.Models;
+internal sealed class GameStatePayload
+{
+    public List<StatePayload>? States { get; set; }
+}

--- a/Daybreak/Services/Scanner/Models/StatePayload.cs
+++ b/Daybreak/Services/Scanner/Models/StatePayload.cs
@@ -1,0 +1,8 @@
+﻿namespace Daybreak.Services.Scanner.Models;
+internal sealed class StatePayload
+{
+    public uint Id { get; set; }
+    public float PosX { get; set; }
+    public float PosY { get; set; }
+    public uint State { get; set; }
+}

--- a/Daybreak/Views/FocusView.xaml
+++ b/Daybreak/Views/FocusView.xaml
@@ -102,6 +102,7 @@
                     <minimap:GuildwarsMinimap x:Name="Minimap"
                                           Visibility="{Binding ElementName=_this, Path=LoadingPathingData, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}"
                                           GameData="{Binding ElementName=_this, Path=GameData, Mode=OneWay}"
+                                          GameState="{Binding ElementName=_this, Path=GameState, Mode=OneWay}"
                                           PathingData="{Binding ElementName=_this, Path=PathingData, Mode=OneWay}"
                                           Zoom="0.04"
                                           ControlsVisible="True"


### PR DESCRIPTION
Rework logic to reuse functions in Utils.h
Rely on GameState for entity positions and state, greatly improves performance
Closes #441 
Closes #439 