### PR TITLE
fix: prevent GW crash when Daybreak API and GWToolbox++ are co-loaded

### DIFF
--- a/Daybreak.API/EntryPoint.cs
+++ b/Daybreak.API/EntryPoint.cs
@@ -135,14 +135,18 @@ public class EntryPoint
         try
         {
             scopedLogger.LogDebug("Initializing GWCA");
-            PreloadNativeDependencies(scopedLogger);
-            var result = GWCA.GW.Initialize();
-            scopedLogger.LogDebug($"GWCA.GW.Initialize() returned: {result}");
+            var gwcaAlreadyInitialized = PreloadNativeDependencies(scopedLogger);
+            if (!gwcaAlreadyInitialized)
+            {
+                var result = GWCA.GW.Initialize();
+                scopedLogger.LogDebug("GWCA.GW.Initialize() returned: {Result}", result);
+            }
+
             await app.RunAsync();
         }
         catch (Exception ex)
         {
-            scopedLogger.LogCritical(ex, $"Encountered fatal error while starting API server {ex}");
+            scopedLogger.LogCritical(ex, "Encountered fatal error while starting API server {Exception}", ex);
             throw;
         }
     }
@@ -180,26 +184,54 @@ public class EntryPoint
         return true;
     }
 
-    private static void PreloadNativeDependencies(ScopedLogger<EntryPoint> logger)
+    // Returns true if gwca.dll was already loaded by another tool (e.g. GWToolbox++),
+    // meaning the caller must NOT call GW::Initialize() — doing so installs a second
+    // set of inline detour hooks on the same GW packet dispatch functions, corrupting
+    // the trampoline chain and crashing GW mid-session.
+    private static bool PreloadNativeDependencies(ScopedLogger<EntryPoint> logger)
     {
+        string? existingGwcaPath = null;
+        string? daybreakGwcaPath = null;
+
         foreach (ProcessModule module in Process.GetCurrentProcess().Modules)
         {
-            if (module.ModuleName?.Contains("Daybreak.API", StringComparison.OrdinalIgnoreCase) is true)
+            if (existingGwcaPath is null
+                && module.ModuleName?.Equals("gwca.dll", StringComparison.OrdinalIgnoreCase) is true)
+            {
+                existingGwcaPath = module.FileName;
+            }
+
+            if (daybreakGwcaPath is null
+                && module.ModuleName?.Contains("Daybreak.API", StringComparison.OrdinalIgnoreCase) is true)
             {
                 var moduleDir = Path.GetDirectoryName(module.FileName)!;
-                var gwcaPath = Path.Combine(moduleDir, "gwca.dll");
-                if (File.Exists(gwcaPath))
+                var candidate = Path.Combine(moduleDir, "gwca.dll");
+                if (File.Exists(candidate))
                 {
-                    NativeLibrary.Load(gwcaPath);
-                    logger.LogDebug($"Preloaded gwca.dll from {gwcaPath}");
+                    daybreakGwcaPath = candidate;
                 }
-                else
-                {
-                    logger.LogError($"gwca.dll not found at {gwcaPath}");
-                }
-
-                break;
             }
         }
+
+        if (existingGwcaPath is not null)
+        {
+            logger.LogWarning(
+                "gwca.dll already loaded at {Path} — reusing existing instance to avoid hook conflicts with co-loaded tools.",
+                existingGwcaPath);
+            // Ensure [DllImport("gwca")] resolves to this instance; LoadLibrary
+            // deduplicates by path so this is a no-op ref-count bump if it's the same file.
+            NativeLibrary.Load(existingGwcaPath);
+            return true;
+        }
+
+        if (daybreakGwcaPath is null)
+        {
+            logger.LogError("gwca.dll not found alongside Daybreak.API — native library not loaded.");
+            return false;
+        }
+
+        NativeLibrary.Load(daybreakGwcaPath);
+        logger.LogDebug("Preloaded gwca.dll from {Path}", daybreakGwcaPath);
+        return false;
     }
 }

--- a/Daybreak.Core/Configuration/ProjectConfiguration.cs
+++ b/Daybreak.Core/Configuration/ProjectConfiguration.cs
@@ -383,8 +383,8 @@ public class ProjectConfiguration : PluginConfigurationBase
     public override void RegisterMods(IModsProducer modsManager)
     {
         modsManager.RegisterMod<IGuildWarsVersionChecker, GuildWarsVersionChecker>();
-        modsManager.RegisterMod<IDaybreakApiService, DaybreakApiService>();
         modsManager.RegisterMod<IToolboxService, ToolboxService>();
+        modsManager.RegisterMod<IDaybreakApiService, DaybreakApiService>();
         modsManager.RegisterMod<IUModService, UModService>();
         modsManager.RegisterMod<IDirectSongService, DirectSongService>(singleton: true);
     }

--- a/Daybreak.Core/Services/ApplicationLauncher/ApplicationLauncher.cs
+++ b/Daybreak.Core/Services/ApplicationLauncher/ApplicationLauncher.cs
@@ -179,18 +179,24 @@ internal sealed class ApplicationLauncher(
         }
 
         var mods = this.modsManager.GetMods();
-        var enabledMods = mods
-            .Where(m =>
-            {
-                var willRun = m.IsInstalled && (launchConfigurationWithCredentials.CustomModLoadoutEnabled
-                        ? !m.CanDisable || (launchConfigurationWithCredentials.EnabledMods?.Contains(m.Name) is true)
-                        : m.IsEnabled);
-                scopedLogger.LogDebug(
-                        "Checking {ModName}.\nIsInstalled: {isInstalled}.\nCanDisable: {canDisable}.\nIsEnabled: {isEnabled}.\nWillRun: {willRun}",
-                        m.Name, m.IsInstalled, m.CanDisable, m.IsEnabled, willRun);
-                return willRun;
-            })
-            .ToList();
+        var customLoadoutNames = launchConfigurationWithCredentials.CustomModLoadoutEnabled
+            ? launchConfigurationWithCredentials.EnabledMods
+            : null;
+        var filteredMods = mods.Where(m =>
+        {
+            var willRun = m.IsInstalled && (customLoadoutNames is not null
+                    ? !m.CanDisable || customLoadoutNames.Contains(m.Name)
+                    : m.IsEnabled);
+            scopedLogger.LogDebug(
+                    "Checking {ModName}.\nIsInstalled: {isInstalled}.\nCanDisable: {canDisable}.\nIsEnabled: {isEnabled}.\nWillRun: {willRun}",
+                    m.Name, m.IsInstalled, m.CanDisable, m.IsEnabled, willRun);
+            return willRun;
+        });
+        // When a custom loadout is active, respect the order the user specified.
+        // Without this, mods always inject in registration order regardless of loadout position.
+        var enabledMods = customLoadoutNames is { Count: > 0 }
+            ? filteredMods.OrderBy(m => customLoadoutNames.IndexOf(m.Name) is var i && i >= 0 ? i : int.MaxValue).ToList()
+            : filteredMods.ToList();
 
         var disabledMods = mods.Except(enabledMods);
         if (this.launcherOptions.CurrentValue.CancelLaunchOutOfDateMods)


### PR DESCRIPTION
Both tools load gwca.dll and call GW::Initialize(), which installs inline detour hooks on the same GW packet dispatch functions. A second Initialize() call corrupts the trampoline chain, causing a STATUS_BREAKPOINT heap corruption crash mid-session.

Three-part fix:
- EntryPoint.cs: PreloadNativeDependencies now detects an existing gwca.dll in the process module list. If found, it reuses that instance via NativeLibrary.Load (a no-op ref-count bump) and returns true so GW::Initialize() is skipped entirely.
- ProjectConfiguration.cs: GWToolbox is now registered before Daybreak API so it injects first by default, ensuring gwca is already present when Daybreak API's check runs.
- ApplicationLauncher.cs: When a custom mod loadout is active, mods are now sorted to match the order specified in the loadout list before injection. Previously the list was used only as a membership filter, silently ignoring the user-specified position of each mod.
- 
Note on gwca versions: Daybreak's bundled gwca.dll (342 KB, updated in [#1528](https://github.com/rebekka-c/Daybreak/issues/1528)) and GWToolbox's gwca.dll (312 KB) are currently different builds. The fix intentionally reuses whichever instance is already in the process rather than loading a second copy, avoiding the incompatible trampoline layouts that cause the heap corruption.